### PR TITLE
FIX: Make regex more cautious

### DIFF
--- a/embedmd
+++ b/embedmd
@@ -110,11 +110,11 @@ sub embedMarkdownInHTML {
   my $contents = `cat $htmlFile`;
 
   # Replace each '#INCLUDE markdown.file' with the markdown converted to HTML.
-  while ($contents =~ m/\#INCLUDE (\S+)/)
+  while ($contents =~ m/\#INCLUDE (\S+\.md)/)
   {
     my $mdFile = $1;
     my $mdAsHTML = `markdown $mdFile`;
-    $contents =~ s/\#INCLUDE \S+/$mdAsHTML/;
+    $contents =~ s/\#INCLUDE \S+\.md/$mdAsHTML/;
   }
 
   return $contents;


### PR DESCRIPTION
If the input HTML or Markdown file contains the string '#INCLUDE XYZ', don't
automatically try to substitute for XYZ.

Make sure it's of the form '#INCLUDE XYZ.md'